### PR TITLE
dumb thread local storage

### DIFF
--- a/nolibc/mmap.c
+++ b/nolibc/mmap.c
@@ -4,10 +4,13 @@
 #include <sys/mman.h>
 
 void *mmap(void *addr, size_t len, int prot, int flags, int fildes, off_t off) {
-  if (addr != NULL) {
-    printf("mmap: non-null addr is unsupported.\n");
-    abort();
-  }
+
+  /* man page for mmap says:
+   * If addr is not NULL, then the kernel takes it as a hint about where to place
+   * the mapping; [...] If another apping already exists there, the kernel picks
+   * a new address that may or *may not* depend on the hint.
+   */
+  (void)addr;
   if (fildes != -1) {
     printf("mmap: file descriptor is unsupported.\n");
     abort();

--- a/nolibc/stubs.c
+++ b/nolibc/stubs.c
@@ -140,7 +140,7 @@ STUB_IGNORE(int, pthread_cond_init, 0);
 STUB_ABORT(pthread_cond_destroy);
 STUB_ABORT(pthread_cond_wait);
 STUB_ABORT(pthread_cond_signal);
-STUB_ABORT(pthread_cond_broadcast);
+STUB_IGNORE(int, pthread_cond_broadcast, 0);
 STUB_ABORT(pthread_self);
 STUB_ABORT(pthread_detach);
 STUB_ABORT(sigfillset);

--- a/nolibc/sysdeps_solo5.c
+++ b/nolibc/sysdeps_solo5.c
@@ -96,6 +96,10 @@ void _nolibc_init(uintptr_t heap_start, size_t heap_size)
 
     sbrk_start = sbrk_cur = heap_start;
     sbrk_end = heap_start + heap_size;
+
+    size_t tdata = 4096; // FIXME: hard coded
+    uintptr_t tls = (uintptr_t)malloc(tdata);
+    solo5_set_tls_base(tls);
 }
 
 /*


### PR DESCRIPTION
This PR permits to start a spt unikernel with Ocaml5, and also as a xen/qubes AppVM (but it needs a lot more memory, here 512MB instead of the usual 32MB for qubes-mirage-firewall for example, I should investigate why):
```
[2022-12-22 16:44:18] Solo5: Xen console: port 0x2, ring @0x00000000FEFFF000
[2022-12-22 16:44:18]             |      ___|
[2022-12-22 16:44:18]   __|  _ \  |  _ \ __ \
[2022-12-22 16:44:18] \__ \ (   | | (   |  ) |
[2022-12-22 16:44:18] ____/\___/ _|\___/____/
[2022-12-22 16:44:18] Solo5: Bindings version v0.7.5
[2022-12-22 16:44:18] Solo5: Memory map: 512 MB addressable:
[2022-12-22 16:44:18] Solo5:   reserved @ (0x0 - 0xfffff)
[2022-12-22 16:44:18] Solo5:       text @ (0x100000 - 0x22afff)
[2022-12-22 16:44:18] Solo5:     rodata @ (0x22b000 - 0x248fff)
[2022-12-22 16:44:18] Solo5:       data @ (0x249000 - 0x31dfff)
[2022-12-22 16:44:18] Solo5:       heap >= 0x31e000 < stack < 0x20000000
[2022-12-22 16:44:18] 2022-12-22 15:44:18 -00:00: INF [application] hello
[2022-12-22 16:44:19] 2022-12-22 15:44:19 -00:00: INF [application] hello
[2022-12-22 16:44:20] 2022-12-22 15:44:20 -00:00: INF [application] hello
[2022-12-22 16:44:21] 2022-12-22 15:44:21 -00:00: INF [application] hello
[2022-12-22 16:44:22] Solo5: solo5_exit(0) called
```
There is still some work to be done to get good threads management (not only stubs, so far only 1 domain can be used :) ), and I need to check how many memory is needed for thread local storage.